### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.i*86
 *.x86_64
 *.hex
+.bin
 
 # Debug files
 *.dSYM/


### PR DESCRIPTION
.bin files are often neglected as executables, but they exist.